### PR TITLE
Add support for QuantAQ MODULAIR gas phase measurements (and fix minor QA/QC parsing bug)

### DIFF
--- a/lib/quantaq-modulair/quantaq-modulair-converter.ts
+++ b/lib/quantaq-modulair/quantaq-modulair-converter.ts
@@ -18,6 +18,11 @@ export class QuantAQModulairConverter extends Converter {
     const series7 = new TimeSeries({ name: 'temp', type: 'NUMBER' })
     const series8 = new TimeSeries({ name: 'ws', type: 'NUMBER' })
     const series9 = new TimeSeries({ name: 'wd', type: 'NUMBER' })
+    const series10 = new TimeSeries({ name: 'no', type: 'NUMBER' })
+    const series11 = new TimeSeries({ name: 'no2', type: 'NUMBER' })
+    const series12 = new TimeSeries({ name: 'o3', type: 'NUMBER' })
+    const series13 = new TimeSeries({ name: 'co', type: 'NUMBER' })
+    const series14 = new TimeSeries({ name: 'co2', type: 'NUMBER' })
 
     // Get the records
     const records = JSON.parse(input.toString())
@@ -30,20 +35,30 @@ export class QuantAQModulairConverter extends Converter {
       pm25: string,
       pm10: string,
       tsp: string,
+      no: string,
+      no2: string,
+      o3: string,
+      co: string,
+      co2: string,
       met: { rh: string, temp: string, ws: string, wd: string } }) => {
       const ts = new Date(row.timestamp)
 
       series1.insert({ timestamp: ts, value: row.sn })
-      series2.insert({ timestamp: ts, value: Number(row.pm1) })
-      series3.insert({ timestamp: ts, value: Number(row.pm25) })
-      series4.insert({ timestamp: ts, value: Number(row.pm10) })
-      series5.insert({ timestamp: ts, value: Number(row.tsp) })
-      series6.insert({ timestamp: ts, value: Number(row.met.rh) })
-      series7.insert({ timestamp: ts, value: Number(row.met.temp) })
-      series8.insert({ timestamp: ts, value: Number(row.met.ws) })
-      series9.insert({ timestamp: ts, value: Number(row.met.wd) })
+      series2.insert({ timestamp: ts, value: parseFloat(row.pm1) })
+      series3.insert({ timestamp: ts, value: parseFloat(row.pm25) })
+      series4.insert({ timestamp: ts, value: parseFloat(row.pm10) })
+      series5.insert({ timestamp: ts, value: parseFloat(row.tsp) })
+      series6.insert({ timestamp: ts, value: parseFloat(row.met.rh) })
+      series7.insert({ timestamp: ts, value: parseFloat(row.met.temp) })
+      series8.insert({ timestamp: ts, value: parseFloat(row.met.ws) })
+      series9.insert({ timestamp: ts, value: parseFloat(row.met.wd) })
+      series10.insert({ timestamp: ts, value: parseFloat(row.no) })
+      series11.insert({ timestamp: ts, value: parseFloat(row.no2) })
+      series12.insert({ timestamp: ts, value: parseFloat(row.o3) })
+      series13.insert({ timestamp: ts, value: parseFloat(row.co) })
+      series14.insert({ timestamp: ts, value: parseFloat(row.co2) })
     })
 
-    return new JtsDocument({ series: [series1, series2, series3, series4, series5, series6, series7, series8, series9] })
+    return new JtsDocument({ series: [series1, series2, series3, series4, series5, series6, series7, series8, series9, series10, series11, series12, series13, series14] })
   }
 }

--- a/lib/quantaq-modulair/test/input-3.dat
+++ b/lib/quantaq-modulair/test/input-3.dat
@@ -1,0 +1,128 @@
+{
+  "data": [
+    {
+      "co": 487.53,
+      "geo": {
+        "lat": null,
+        "lon": null
+      },
+      "met": {
+        "rh": 37.5,
+        "temp": 16.2,
+        "wd": 0,
+        "ws": 0
+      },
+      "model": {
+        "gas": {
+          "co": 14300,
+          "no": 14302,
+          "no2": 14303,
+          "o3": 14301
+        },
+        "pm": {
+          "pm1": 14297,
+          "pm10": 14299,
+          "pm25": 14298
+        }
+      },
+      "no": 6.82,
+      "no2": 9.77,
+      "o3": 14.8,
+      "pm1": 0.03,
+      "pm10": 1.69,
+      "pm25": 0.2,
+      "rh": 37.5,
+      "sn": "MOD-RND-2",
+      "temp": 16.2,
+      "timestamp": "2024-04-04T21:46:37",
+      "timestamp_local": "2024-04-04T17:46:37",
+      "url": "https://api.quant-aq.com/v1/devices/MOD-RND-2/data/121958267"
+    },
+    {
+      "co": 487.05,
+      "geo": {
+        "lat": null,
+        "lon": null
+      },
+      "met": {
+        "rh": 37.6,
+        "temp": 16.2,
+        "wd": 0,
+        "ws": 0
+      },
+      "model": {
+        "gas": {
+          "co": 14300,
+          "no": 14302,
+          "no2": 14303,
+          "o3": 14301
+        },
+        "pm": {
+          "pm1": null,
+          "pm10": null,
+          "pm25": null
+        }
+      },
+      "no": 6.75,
+      "no2": 9.54,
+      "o3": 15.65,
+      "pm1": null,
+      "pm10": null,
+      "pm25": null,
+      "rh": 37.6,
+      "sn": "MOD-RND-2",
+      "temp": 16.2,
+      "timestamp": "2024-04-04T21:45:37",
+      "timestamp_local": "2024-04-04T17:45:37",
+      "url": "https://api.quant-aq.com/v1/devices/MOD-RND-2/data/121958264"
+    },
+    {
+      "co": 473.16,
+      "geo": {
+        "lat": null,
+        "lon": null
+      },
+      "met": {
+        "rh": 37.5,
+        "temp": 16.2,
+        "wd": 0,
+        "ws": 0
+      },
+      "model": {
+        "gas": {
+          "co": 14300,
+          "no": 14302,
+          "no2": 14303,
+          "o3": 14301
+        },
+        "pm": {
+          "pm1": 14297,
+          "pm10": 14299,
+          "pm25": 14298
+        }
+      },
+      "no": 6.16,
+      "no2": 9.77,
+      "o3": 15.39,
+      "pm1": 0.08,
+      "pm10": 0.34,
+      "pm25": 0.18,
+      "rh": 37.5,
+      "sn": "MOD-RND-2",
+      "temp": 16.2,
+      "timestamp": "2024-04-04T21:44:37",
+      "timestamp_local": "2024-04-04T17:44:37",
+      "url": "https://api.quant-aq.com/v1/devices/MOD-RND-2/data/121958265"
+    }
+  ],
+  "meta": {
+    "first_url": "https://api.quant-aq.com/v1/devices/MOD-RND-2/data/?page=1&per_page=100&limit=3&sort=timestamp,desc",
+    "last_url": "https://api.quant-aq.com/v1/devices/MOD-RND-2/data/?page=1&per_page=100&limit=3&sort=timestamp,desc",
+    "next_url": null,
+    "page": 1,
+    "pages": 1,
+    "per_page": 100,
+    "prev_url": null,
+    "total": 3
+  }
+}

--- a/lib/quantaq-modulair/test/quantaq-modulair-converter.test.ts
+++ b/lib/quantaq-modulair/test/quantaq-modulair-converter.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import { QuantAQModulairConverter } from '../quantaq-modulair-converter'
 
-describe('Unit test for QuantAQ MODULAIR Sensors', function () {
+describe('Unit test for SKU=000 QuantAQ MODULAIR Sensors', function () {
   it('converts sample file', async () => {
     const converter = new QuantAQModulairConverter()
     const buff = fs.readFileSync('lib/quantaq-modulair/test/input.dat')
@@ -33,11 +33,26 @@ describe('Unit test for QuantAQ MODULAIR Sensors', function () {
 
     // Check the WD data
     expect(result.series[8].values).toEqual([0, 0, 0])
+
+    // Check the NO data
+    expect(result.series[9].values).toEqual([NaN, NaN, NaN])
+
+    // Check the NO2 data
+    expect(result.series[10].values).toEqual([NaN, NaN, NaN])
+
+    // Check the O3 data
+    expect(result.series[11].values).toEqual([NaN, NaN, NaN])
+
+    // Check the CO data
+    expect(result.series[12].values).toEqual([NaN, NaN, NaN])
+
+    // Check the CO2 data
+    expect(result.series[13].values).toEqual([NaN, NaN, NaN])
   })
 })
 
 // Run unit tests for a SKU=000 with no TSP model
-describe('Unit test for QuantAQ MODULAIR Sensor without TSP enabled', function () {
+describe('Unit test for SKU=000 QuantAQ MODULAIR Sensor without TSP enabled', function () {
   it('converts sample file', async () => {
     const converter = new QuantAQModulairConverter()
     const buff = fs.readFileSync('lib/quantaq-modulair/test/input-2.dat')
@@ -69,5 +84,71 @@ describe('Unit test for QuantAQ MODULAIR Sensor without TSP enabled', function (
 
     // Check the WD data
     expect(result.series[8].values).toEqual([NaN, NaN, NaN])
+
+    // Check the NO data
+    expect(result.series[9].values).toEqual([NaN, NaN, NaN])
+
+    // Check the NO2 data
+    expect(result.series[10].values).toEqual([NaN, NaN, NaN])
+
+    // Check the O3 data
+    expect(result.series[11].values).toEqual([NaN, NaN, NaN])
+
+    // Check the CO data
+    expect(result.series[12].values).toEqual([NaN, NaN, NaN])
+
+    // Check the CO2 data
+    expect(result.series[13].values).toEqual([NaN, NaN, NaN])
+  })
+})
+
+// Run unit tests for a SKU=015 with no TSP model
+describe('Unit test for SKU=015 QuantAQ MODULAIR Sensor without TSP enabled', function () {
+  it('converts sample file', async () => {
+    const converter = new QuantAQModulairConverter()
+    const buff = fs.readFileSync('lib/quantaq-modulair/test/input-3.dat')
+    const result = converter.convert(buff)
+
+    // Check the serial number
+    expect(result.series[0].values).toEqual(['MOD-RND-2', 'MOD-RND-2', 'MOD-RND-2'])
+
+    // Check the PM1 data
+    expect(result.series[1].values).toEqual([0.03, NaN, 0.08])
+
+    // Check the PM2.5 data
+    expect(result.series[2].values).toEqual([0.2, NaN, 0.18])
+
+    // Check the PM10 data
+    expect(result.series[3].values).toEqual([1.69, NaN, 0.34])
+
+    // Check the TSP data
+    expect(result.series[4].values).toEqual([NaN, NaN, NaN])
+
+    // Check the RH data
+    expect(result.series[5].values).toEqual([37.5, 37.6, 37.5])
+
+    // Check the Temp data
+    expect(result.series[6].values).toEqual([16.2, 16.2, 16.2])
+
+    // Check the WS data
+    expect(result.series[7].values).toEqual([0, 0, 0])
+
+    // Check the WD data
+    expect(result.series[8].values).toEqual([0, 0, 0])
+
+    // Check the NO data
+    expect(result.series[9].values).toEqual([6.82, 6.75, 6.16])
+
+    // Check the NO2 data
+    expect(result.series[10].values).toEqual([9.77, 9.54, 9.77])
+
+    // Check the O3 data
+    expect(result.series[11].values).toEqual([14.8, 15.65, 15.39])
+
+    // Check the CO data
+    expect(result.series[12].values).toEqual([487.53, 487.05, 473.16])
+
+    // Check the CO2 data
+    expect(result.series[13].values).toEqual([NaN, NaN, NaN])
   })
 })


### PR DESCRIPTION
Hello Eagle.io team!

This PR updates our QuantAQ MODULAIR integration to additionally support our instruments' gas phase measurements, on top of the existing particulate matter measurement integration. 

It also fixes a minor bug in the existing integration, where under some circumstances, omitted measurements were being parsed as `0`s instead of `NaN`s.

One of your customers eagerly awaits the deployment of this integration. Let me know if there's anything else I can do to help it get merged. Cheers!