### PR TITLE
fix(das-captis-v2): stabilise column indices

### DIFF
--- a/lib/das-captis-v2/das-captis-v2-converter.ts
+++ b/lib/das-captis-v2/das-captis-v2-converter.ts
@@ -13,7 +13,10 @@ export class DASCaptisV2Converter extends Converter {
     const seriesMap: SeriesMap = {
       event: new TimeSeries({ name: 'eventCode + eventNotes', type: 'TEXT' }),
       battery: new TimeSeries({ name: 'battery', type: 'NUMBER', units: 'V' }),
-      signalStrength: new TimeSeries({ name: 'signalStrength', type: 'NUMBER', units: 'dBm' })
+      signalStrength: new TimeSeries({ name: 'signalStrength', type: 'NUMBER', units: 'dBm' }),
+      flow: new TimeSeries({ name: 'flow', type: 'NUMBER' }),
+      flow1: new TimeSeries({ name: 'flow1', type: 'NUMBER' }),
+      flow2: new TimeSeries({ name: 'flow2', type: 'NUMBER' })
     }
     const serverTime = this.dayjs().toDate()
 
@@ -26,9 +29,6 @@ export class DASCaptisV2Converter extends Converter {
         const seriesName = parts[1]
 
         if (seriesName === 'flow' || seriesName === 'flow1' || seriesName === 'flow2') {
-          if (!seriesMap[seriesName]) {
-            seriesMap[seriesName] = new TimeSeries({ name: seriesName, type: 'NUMBER' })
-          }
           seriesMap[seriesName].insert({ timestamp, value })
         }
         return
@@ -41,9 +41,6 @@ export class DASCaptisV2Converter extends Converter {
 
       if (id === 'l003' && parts[1] && this.dayjs(parts[1]).isValid()) {
         const timestamp = this.dayjs(parts[1]).toDate()
-        if (!seriesMap.flow) {
-          seriesMap.flow = new TimeSeries({ name: 'flow', type: 'NUMBER' })
-        }
         seriesMap.flow.insert({ timestamp, value: Number(parts[2]) })
         return
       }

--- a/lib/das-captis-v2/test/das-captis-v2-converter.test.ts
+++ b/lib/das-captis-v2/test/das-captis-v2-converter.test.ts
@@ -57,4 +57,41 @@ describe('Unit test for Captis converter', function () {
       expect(modbusFlow2Series.first?.value).toEqual(3145731.0)
     }
   })
+
+  it('emits stable column order when optional flow series are absent', () => {
+    const converter = new DASCaptisV2Converter()
+    // Input contains only flow1/flow2 records - no `flow` or `l003` rows.
+    // Column order must still be [event, battery, signalStrength, flow, flow1, flow2]
+    // so that downstream ingest routes data to the correct seriesId.
+    const input = Buffer.from(
+      [
+        'l011,,3.58',
+        'radio,,-91,-12',
+        'a00091-00001,2026-04-28T15:00:00Z',
+        '200,flow1,flow1,18744,units,2026-04-28T16:00:00Z',
+        '200,flow2,flow2,476010592,units,2026-04-28T16:00:00Z'
+      ].join('\n')
+    )
+
+    const result = converter.convert(input)
+    const names = result.series.map(s => s.name)
+
+    expect(names).toEqual([
+      'eventCode + eventNotes',
+      'battery',
+      'signalStrength',
+      'flow',
+      'flow1',
+      'flow2'
+    ])
+
+    const flow = result.series.find(s => s.name === 'flow')
+    const flow1 = result.series.find(s => s.name === 'flow1')
+    const flow2 = result.series.find(s => s.name === 'flow2')
+
+    // flow received no data but must still be present (empty) to hold its column slot
+    expect(flow?.values).toEqual([])
+    expect(flow1?.values).toEqual([18744])
+    expect(flow2?.values).toEqual([476010592])
+  })
 })


### PR DESCRIPTION
## Problem

When the input CSV omits any of the optional `flow` / `flow1` / `flow2` records, the previous implementation lazily created those series on first sight, so the emitted JTS column indices depended on which records happened to appear.

Because eagle.io template-instance datasources trust the persisted `tables.columns` layout by index (see `TableProcessor.buildJtsColumns` / `Datasource.manageTable`), shifted indices silently misrouted data:

| Input contains | Emitted columns | Effect on ingest |
| --- | --- | --- |
| flow + flow1 + flow2 | 0 event, 1 battery, 2 signal, **3 flow, 4 flow1, 5 flow2** | correct (matches template) |
| flow1 + flow2 only | 0 event, 1 battery, 2 signal, **3 flow1, 4 flow2** | flow1 data dropped; flow2 data lands in flow1 series |
| flow + flow2 only | 0 event, 1 battery, 2 signal, **3 flow, 4 flow2** | flow2 data lands in flow1 series |

Observed in the wild on node `69a616978f602af225a860bd` (`6563-2-LID03`) — flow1 point ended up with flow2's magnitudes.

## Fix

Pre-declare `flow`, `flow1` and `flow2` in `seriesMap` up-front so column order is always `[event, battery, signalStrength, flow, flow1, flow2]` regardless of input contents, matching the template's stored column layout. Removed the now-redundant lazy-init blocks.

## Tests

Existing `das-captis-v2-converter.test.ts` still passes (input already produces all three flow series). A follow-up test with an input that omits one or more flow series would guard against future regressions.

## Follow-ups (not in this PR)

- Data remediation on affected instances: historical flow1 values were dropped and flow1 series contains flow2 magnitudes over the drift window.
- Backend hardening: add a name-vs-index consistency check in `TableProcessor.performIngest` so future header/template drift fails loudly instead of silently mis-mapping.